### PR TITLE
Fix race condition where despawned entity cannot be drawn.

### DIFF
--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -94,7 +94,12 @@ public class StandardPlayfield implements Playfield {
     public void drawEntities() {
         final List<Drawable> drawables = new ArrayList<>();
         for (final Entity entity : this.getAllEntities()) {
-            drawables.add(entity.getDrawInformation());
+            try {
+                drawables.add(entity.getDrawInformation());
+            } catch (@SuppressWarnings("unused") EntityNotOnFieldException e) {
+                //Entity has been removed from the field while this loop was running.
+                //Just don't draw it and ignore the exception.
+            }
         }
         if (this.drawer != null) {
             this.drawer.setDrawables(drawables);


### PR DESCRIPTION
When an entity despawns while the playfield iterates over all entities to draw them,
an EntityNotOnField Exception is thrown there.
Now this exception is just ignored and the entity not drawn,
as it has just been removed from the playfield.

Fixes: #75