### PR TITLE
Refactor logging

### DIFF
--- a/ICGE-Log/src/main/java/de/unistuttgart/informatik/fius/icge/log/Logger.java
+++ b/ICGE-Log/src/main/java/de/unistuttgart/informatik/fius/icge/log/Logger.java
@@ -14,37 +14,26 @@ import java.io.PrintStream;
 
 
 /**
- * The main class for all the logging.
+ * Helper class that intercepts {@code System.out} and {@code System.err} and allows to attach multiple streams to
+ * capture the outputs of intercepted streams.
  *
  * @author Tim Neumann
  * @author Tobias Wältken
- * @version 1.0
+ * @author Fabian Bühler
+ * @version 2.0
  */
 public abstract class Logger {
     
-    /** The logger for the simulation */
-    public static PrintStream simout;
-    /** The error logger of the simulaiton */
-    public static PrintStream simerror;
     /** The main logger printing to {@link System#out} */
     public static PrintStream out;
     /** The error logger printing to {@link System#err} */
     public static PrintStream error;
     
-    private static OutputStreamMultiplier simoutStream;
-    private static OutputStreamMultiplier simerrorStream;
     private static OutputStreamMultiplier outStream;
     private static OutputStreamMultiplier errorStream;
     
-    // This block setups all the loggers and intercepts {@link System.out} and {@link System.err}
+    // This block intercepts {@link System.out} and {@link System.err}
     static {
-        Logger.simoutStream = new OutputStreamMultiplier();
-        Logger.simout = new PrintStream(Logger.simoutStream);
-        
-        Logger.simerrorStream = new OutputStreamMultiplier();
-        Logger.simerrorStream.addOutputStream(System.err);
-        Logger.simerror = new PrintStream(Logger.simerrorStream);
-        
         Logger.outStream = new OutputStreamMultiplier();
         Logger.outStream.addOutputStream(System.out);
         Logger.out = new PrintStream(Logger.outStream);
@@ -54,72 +43,6 @@ public abstract class Logger {
         Logger.errorStream.addOutputStream(System.err);
         Logger.error = new PrintStream(Logger.errorStream);
         System.setErr(Logger.error);
-    }
-    
-    /**
-     * Function to add a {@link OutputStream} to the simulation logger
-     *
-     * @param stream
-     *     The {@link OutputStream} to add
-     * @return Returns true if successfull
-     * @see OutputStreamMultiplier#addOutputStream(OutputStream)
-     */
-    public static boolean addSimulationOutputStream(final OutputStream stream) {
-        return Logger.simoutStream.addOutputStream(stream);
-    }
-    
-    /**
-     * Function to remove a {@link OutputStream} from the simulation logger
-     *
-     * @param stream
-     *     The {@link OutputStream} to remove
-     * @return Returns true if successfull
-     * @see OutputStreamMultiplier#removeOutputStream(OutputStream)
-     */
-    public static boolean removeSimulationOutputStream(final OutputStream stream) {
-        return Logger.simoutStream.removeOutputStream(stream);
-    }
-    
-    /**
-     * Clears the simulation OutputStreams
-     *
-     * @see OutputStreamMultiplier#clearOutputStreams()
-     */
-    public static void clearSimulationOutputStream() {
-        Logger.simoutStream.clearOutputStreams();
-    }
-    
-    /**
-     * Function to add a {@link OutputStream} to the simulation error logger
-     *
-     * @param stream
-     *     The {@link OutputStream} to add
-     * @return Returns true if successfull
-     * @see OutputStreamMultiplier#addOutputStream(OutputStream)
-     */
-    public static boolean addSimulationErrorStream(final OutputStream stream) {
-        return Logger.simerrorStream.addOutputStream(stream);
-    }
-    
-    /**
-     * Function to remove a {@link OutputStream} from the simulation error logger
-     *
-     * @param stream
-     *     The {@link OutputStream} to remove
-     * @return Returns true if successfull
-     * @see OutputStreamMultiplier#removeOutputStream(OutputStream)
-     */
-    public static boolean removeSimulationErrorStream(final OutputStream stream) {
-        return Logger.simerrorStream.removeOutputStream(stream);
-    }
-    
-    /**
-     * Clears the simulation error OutputStreams
-     *
-     * @see OutputStreamMultiplier#clearOutputStreams()
-     */
-    public static void clearSimulationErrorStream() {
-        Logger.simerrorStream.clearOutputStreams();
     }
     
     /**

--- a/ICGE-Log/src/main/java/de/unistuttgart/informatik/fius/icge/log/OutputStreamMultiplier.java
+++ b/ICGE-Log/src/main/java/de/unistuttgart/informatik/fius/icge/log/OutputStreamMultiplier.java
@@ -75,4 +75,11 @@ public class OutputStreamMultiplier extends OutputStream {
             listenerStream.write(arg0);
         }
     }
+    
+    @Override
+    public void close() throws IOException {
+        for (final OutputStream listenerStream : this.listenerStreams) {
+            listenerStream.close();
+        }
+    }
 }

--- a/ICGE-ManualStart/src/main/java/de/unistuttgart/informatik/fius/icge/manualstart/ManualStartSimulation.java
+++ b/ICGE-ManualStart/src/main/java/de/unistuttgart/informatik/fius/icge/manualstart/ManualStartSimulation.java
@@ -34,8 +34,8 @@ public class ManualStartSimulation {
     public static void main(final String[] args) {
         final WindowBuilder wb = new WindowBuilder();
         wb.setTitle("Window Builder start!");
-        wb.buildWindow();
         wb.setGraphicsSettings(false, true);
+        wb.buildWindow();
         final GameWindow w = wb.getBuiltWindow();
         
         ManualStartSimulation.prepareTextures(w.getTextureRegistry());

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
-import de.unistuttgart.informatik.fius.icge.log.Logger;
 import de.unistuttgart.informatik.fius.icge.simulation.Position;
 import de.unistuttgart.informatik.fius.icge.simulation.entity.Entity;
 import de.unistuttgart.informatik.fius.icge.simulation.exception.CannotRunProgramException;
@@ -241,8 +240,8 @@ public class StandardSimulationProxy implements SimulationProxy {
             final Entity entity = this.entityTypeRegistry.getNewEntity(typeName);
             return this.entityProgramRegistry.getProgramsForEntity(entity);
         } catch (final Exception e) {
-            Logger.simout.println("Could not load program list for entity type " + typeName + ". (See system log for details.)");
-            e.printStackTrace(Logger.error);
+            System.out.println("Could not load program list for entity type " + typeName + ".");
+            e.printStackTrace();
         }
         return new HashSet<>();
     }
@@ -252,17 +251,17 @@ public class StandardSimulationProxy implements SimulationProxy {
         try {
             final Entity ent = this.entityTypeRegistry.getNewEntity(typeName);
             if (ent == null) {
-                Logger.simout.println("Could not create a new entity of type " + typeName + "!");
+                System.out.println("Could not create a new entity of type " + typeName + "!");
                 return;
             }
             this.playfield.addEntity(new Position(x, y), ent);
             //TODO: Run program or remove that feature.
         } catch (final CannotRunProgramException e) {
-            Logger.simout.println("Could not run program " + program + " for the new entity. (See system log for details.)");
-            e.printStackTrace(Logger.error);
+            System.out.println("Could not run program " + program + " for the new entity.");
+            e.printStackTrace();
         } catch (final Exception e) {
-            Logger.simout.println("Something went wrong while creating new entity. (See system log for details.)");
-            e.printStackTrace(Logger.error);
+            System.out.println("Something went wrong while creating new entity.");
+            e.printStackTrace();
         }
     }
     

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/actions/StandardActionLog.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/actions/StandardActionLog.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import de.unistuttgart.informatik.fius.icge.log.Logger;
 import de.unistuttgart.informatik.fius.icge.simulation.MultiTypedList;
 import de.unistuttgart.informatik.fius.icge.simulation.actions.Action;
 import de.unistuttgart.informatik.fius.icge.simulation.actions.ActionLog;
@@ -70,7 +69,7 @@ public class StandardActionLog implements ActionLog {
             this.entityActions.get(entity).add(entityAction);
         }
         this.actions.add(actionToLog);
-        Logger.simout.println(actionToLog.getDescription());
+        System.out.println(actionToLog.getDescription());
     }
     
 }

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/entity/StandardEntityTypeRegistry.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/entity/StandardEntityTypeRegistry.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
-import de.unistuttgart.informatik.fius.icge.log.Logger;
 import de.unistuttgart.informatik.fius.icge.simulation.entity.Entity;
 import de.unistuttgart.informatik.fius.icge.simulation.entity.EntityTypeRegistry;
 import de.unistuttgart.informatik.fius.icge.simulation.exception.ElementExistsException;
@@ -44,7 +43,7 @@ public class StandardEntityTypeRegistry implements EntityTypeRegistry {
                     NoSuchMethodException | InstantiationException | IllegalAccessException | IllegalArgumentException
                     | InvocationTargetException e
             ) {
-                e.printStackTrace(Logger.error);
+                e.printStackTrace();
                 // could not instantiate a new entity
                 return null;
             }

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/entity/program/StandardEntityProgramRunner.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/entity/program/StandardEntityProgramRunner.java
@@ -19,7 +19,6 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinPool.ForkJoinWorkerThreadFactory;
 import java.util.concurrent.ForkJoinWorkerThread;
 
-import de.unistuttgart.informatik.fius.icge.log.Logger;
 import de.unistuttgart.informatik.fius.icge.simulation.entity.Entity;
 import de.unistuttgart.informatik.fius.icge.simulation.entity.program.EntityProgramRunner;
 import de.unistuttgart.informatik.fius.icge.simulation.entity.program.EntityProgramState;
@@ -140,10 +139,10 @@ public class StandardEntityProgramRunner implements EntityProgramRunner {
                 //TODO: If a way is added to see/use the log messages of an old simulation we need to fix this
                 info.setState(EntityProgramState.KILLED);
             } catch (final Exception e) {
-                Logger.simout.println("----------------------------------------------");
-                Logger.simout.println("The following exception happened in program " + program + " running on entity " + entity.toString());
-                e.printStackTrace(Logger.simerror);
-                Logger.simout.println("----------------------------------------------");
+                System.out.println("----------------------------------------------");
+                System.out.println("The following exception happened in program " + program + " running on entity " + entity.toString());
+                e.printStackTrace();
+                System.out.println("----------------------------------------------");
                 info.setState(EntityProgramState.KILLED);
             }
             return null;

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/tasks/StandardTaskRunner.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/tasks/StandardTaskRunner.java
@@ -12,7 +12,6 @@ package de.unistuttgart.informatik.fius.icge.simulation.internal.tasks;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
-import de.unistuttgart.informatik.fius.icge.log.Logger;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
 import de.unistuttgart.informatik.fius.icge.simulation.tasks.Task;
 
@@ -58,16 +57,16 @@ public class StandardTaskRunner {
             return true;
         } catch (final CancellationException e) {
             //Simulation was stopped before completion of the task.
-            Logger.simout.println("----------------------------------------------");
-            Logger.simout.println("The task was aborted.");
-            e.printStackTrace(Logger.simerror);
-            Logger.simout.println("----------------------------------------------");
+            System.out.println("----------------------------------------------");
+            System.out.println("The task was aborted.");
+            e.printStackTrace();
+            System.out.println("----------------------------------------------");
             return false;
         } catch (final Exception e) {
-            Logger.simout.println("----------------------------------------------");
-            Logger.simout.println("The following exception caused a task failure:");
-            e.printStackTrace(Logger.simerror);
-            Logger.simout.println("----------------------------------------------");
+            System.out.println("----------------------------------------------");
+            System.out.println("The following exception caused a task failure:");
+            e.printStackTrace();
+            System.out.println("----------------------------------------------");
             return false;
         }
     }

--- a/ICGE-Simulation/src/main/java/module-info.java
+++ b/ICGE-Simulation/src/main/java/module-info.java
@@ -9,7 +9,6 @@
  */
 module de.unistuttgart.informatik.fius.icge.simulation {
     requires transitive de.unistuttgart.informatik.fius.icge.ui;
-    requires de.unistuttgart.informatik.fius.icge.log;
     
     exports de.unistuttgart.informatik.fius.icge.simulation;
     exports de.unistuttgart.informatik.fius.icge.simulation.entity;

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/Console.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/Console.java
@@ -9,47 +9,16 @@
  */
 package de.unistuttgart.informatik.fius.icge.ui;
 
-import java.io.OutputStream;
-
-
 /**
  * A Console to show text output of the software
  *
  * @author Tobias Wältken
- * @version 1.0
+ * @version 2.0
  */
 public interface Console {
     
     /**
-     * Getter for the output stream of the simulation console
-     *
-     * @return Returns a output stream
+     * Clears the console in the ui.
      */
-    OutputStream getSimulationOutputStream();
-    
-    /**
-     * Getter for the error stream of the simulation console
-     * 
-     * @return Returns a output stream
-     */
-    OutputStream getSimulationErrorStream();
-    
-    /**
-     * Getter for the output stream of the system console
-     *
-     * @return Returns a output stream
-     */
-    OutputStream getSystemOutputStream();
-    
-    /**
-     * Getter for the error stream of the system console
-     *
-     * @return Returns a error stream
-     */
-    OutputStream getSystemErrorStream();
-    
-    /**
-     * Clears the simulation console in the ui.
-     */
-    void clearSimulationConsole();
+    void clearConsole();
 }

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/OutputStyle.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/OutputStyle.java
@@ -16,9 +16,9 @@ package de.unistuttgart.informatik.fius.icge.ui.internal;
  */
 public enum OutputStyle {
     
-    /** Standard Style for normal text without any purpos (Black) */
+    /** Standard Style for text from stdout */
     STANDARD,
     
-    /** Style for errors (Red) */
+    /** Style for text from stderr (e.g. errors) */
     ERROR
 }

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingConsole.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingConsole.java
@@ -10,6 +10,7 @@
 package de.unistuttgart.informatik.fius.icge.ui.internal;
 
 import java.awt.Font;
+import java.io.IOException;
 
 import javax.swing.JTextPane;
 import javax.swing.text.DefaultCaret;
@@ -63,5 +64,11 @@ public class SwingConsole extends JTextPane implements Console {
     public void cleanup() {
         Logger.removeOutOutputStream(this.systemOutputStream);
         Logger.removeErrorOutputStream(this.systemErrorStream);
+        try { // stop timers in ConsoleBufferedOutputStreams
+            this.systemOutputStream.close();
+            this.systemErrorStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingConsole.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingConsole.java
@@ -50,14 +50,6 @@ public class SwingConsole extends JTextPane implements Console {
         
         Logger.addOutOutputStream(this.systemOutputStream);
         Logger.addErrorOutputStream(this.systemErrorStream);
-        
-        // Add consoles to the TabbedPane
-        //this.add(new JScrollPane(this.systemConsole));
-        
-        for (int i = 0; i < 20; i++) {
-            System.out.println("Hello world!");
-            System.err.println("Hello error!");
-        }
     }
     
     @Override

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingConsole.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingConsole.java
@@ -9,16 +9,13 @@
  */
 package de.unistuttgart.informatik.fius.icge.ui.internal;
 
-import java.awt.Dimension;
 import java.awt.Font;
-import java.io.OutputStream;
 
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
 import javax.swing.text.DefaultCaret;
 import javax.swing.text.DefaultStyledDocument;
 
+import de.unistuttgart.informatik.fius.icge.log.Logger;
 import de.unistuttgart.informatik.fius.icge.ui.Console;
 
 
@@ -27,16 +24,12 @@ import de.unistuttgart.informatik.fius.icge.ui.Console;
  *
  * @author Tobias Wältken
  * @author David Ruff
- * @version 1.0
+ * @author Fabian Bühler
+ * @version 2.0
  */
-public class SwingConsole extends JPanel implements Console {
+public class SwingConsole extends JTextPane implements Console {
     private static final long serialVersionUID = 5100186594058483257L;
     
-    private JTextPane simulationConsole;
-    private JTextPane systemConsole;
-    
-    private ConsoleBufferedOutputStream simulationOutputStream;
-    private ConsoleBufferedOutputStream simulationErrorStream;
     private ConsoleBufferedOutputStream systemOutputStream;
     private ConsoleBufferedOutputStream systemErrorStream;
     
@@ -44,57 +37,39 @@ public class SwingConsole extends JPanel implements Console {
      * Default constructor
      */
     public SwingConsole() {
+        super(new DefaultStyledDocument());
+        
         final Font standardFont = new Font("monospaced", Font.PLAIN, 12);
-        {   // Setup simulation console
-            this.simulationConsole = new JTextPane(new DefaultStyledDocument());
-            this.simulationConsole.setEditable(false);
-            this.simulationConsole.setFont(standardFont);
-            final DefaultCaret caret = (DefaultCaret) this.simulationConsole.getCaret();
-            caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE);
-            this.simulationOutputStream = new ConsoleBufferedOutputStream(this.simulationConsole, OutputStyle.STANDARD);
-            this.simulationErrorStream = new ConsoleBufferedOutputStream(this.simulationConsole, OutputStyle.ERROR);
-        }
-        {   // Setup system console
-            this.systemConsole = new JTextPane(new DefaultStyledDocument());
-            this.systemConsole.setEditable(false);
-            this.systemConsole.setFont(standardFont);
-            final DefaultCaret caret = (DefaultCaret) this.systemConsole.getCaret();
-            caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE);
-            this.systemOutputStream = new ConsoleBufferedOutputStream(this.systemConsole, OutputStyle.STANDARD);
-            this.systemErrorStream = new ConsoleBufferedOutputStream(this.systemConsole, OutputStyle.ERROR);
-            
-        }
+        
+        this.setEditable(false);
+        this.setFont(standardFont);
+        final DefaultCaret caret = (DefaultCaret) this.getCaret();
+        caret.setUpdatePolicy(DefaultCaret.ALWAYS_UPDATE);
+        this.systemOutputStream = new ConsoleBufferedOutputStream(this, OutputStyle.STANDARD);
+        this.systemErrorStream = new ConsoleBufferedOutputStream(this, OutputStyle.ERROR);
+        
+        Logger.addOutOutputStream(this.systemOutputStream);
+        Logger.addErrorOutputStream(this.systemErrorStream);
+        
         // Add consoles to the TabbedPane
-        this.add(new JScrollPane(this.simulationConsole));
+        //this.add(new JScrollPane(this.systemConsole));
+        
+        for (int i = 0; i < 20; i++) {
+            System.out.println("Hello world!");
+            System.err.println("Hello error!");
+        }
     }
     
     @Override
-    public OutputStream getSimulationOutputStream() {
-        return this.simulationOutputStream;
+    public void clearConsole() {
+        this.setText("");
     }
     
-    @Override
-    public OutputStream getSimulationErrorStream() {
-        return this.simulationErrorStream;
-    }
-    
-    @Override
-    public OutputStream getSystemOutputStream() {
-        return this.systemOutputStream;
-    }
-    
-    @Override
-    public OutputStream getSystemErrorStream() {
-        return this.systemErrorStream;
-    }
-    
-    @Override
-    public void clearSimulationConsole() {
-        this.simulationConsole.setText("");
-    }
-    
-    @Override
-    public Dimension getPreferredSize() {
-        return new Dimension(400, 200);
+    /**
+     * Detach the internal output streams from {@code Logger.out} and {@code Logger.error}.
+     */
+    public void cleanup() {
+        Logger.removeOutOutputStream(this.systemOutputStream);
+        Logger.removeErrorOutputStream(this.systemErrorStream);
     }
 }

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingGameWindow.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingGameWindow.java
@@ -10,18 +10,20 @@
 package de.unistuttgart.informatik.fius.icge.ui.internal;
 
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
 import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
+import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
 
-import de.unistuttgart.informatik.fius.icge.log.Logger;
 import de.unistuttgart.informatik.fius.icge.ui.Console;
 import de.unistuttgart.informatik.fius.icge.ui.EntitySidebar;
 import de.unistuttgart.informatik.fius.icge.ui.GameWindow;
@@ -45,7 +47,7 @@ public class SwingGameWindow extends JFrame implements GameWindow {
     private final SwingPlayfieldDrawer playfieldDrawer;
     private final SwingToolbar         toolbar;
     private final SwingEntitySidebar   entitySidebar;
-    private final Console              console;
+    private final SwingConsole         console;
     
     /**
      * Create a new Swing game window using the given submodules.
@@ -63,7 +65,7 @@ public class SwingGameWindow extends JFrame implements GameWindow {
      */
     public SwingGameWindow(
             final SwingTextureRegistry textureRegistry, final SwingPlayfieldDrawer playfieldDrawer, final SwingToolbar toolbar,
-            final SwingEntitySidebar entitySidebar, final Console console
+            final SwingEntitySidebar entitySidebar, final SwingConsole console
     ) {
         this.textureRegistry = textureRegistry;
         this.playfieldDrawer = playfieldDrawer;
@@ -145,20 +147,20 @@ public class SwingGameWindow extends JFrame implements GameWindow {
         // convert console
         JComponent consoleComponent;
         try {
-            consoleComponent = (JComponent) this.console;
-        } catch (ClassCastException | NullPointerException e) {
+            consoleComponent = this.console;
+        } catch (NullPointerException e) {
             consoleComponent = new JLabel("Console not valid!", UIManager.getIcon("OptionPane.warningIcon"), SwingConstants.CENTER);
         }
         
-        // connect logger to console
-        Logger.addSimulationOutputStream(this.console.getSimulationOutputStream());
-        Logger.addSimulationErrorStream(this.console.getSimulationErrorStream());
-        Logger.addOutOutputStream(this.console.getSystemOutputStream());
-        Logger.addErrorOutputStream(this.console.getSystemErrorStream());
+        // setup bottom pane layout
+        final JTabbedPane bottomPane = new JTabbedPane(SwingConstants.TOP, JTabbedPane.SCROLL_TAB_LAYOUT);
+        bottomPane.addTab("Console", new JScrollPane(consoleComponent));
+        bottomPane.setPreferredSize(new Dimension(400, 200));
+        // TODO task status component: bottomPane.addTab("Task Status", null);
         
         // setup JFrame layout
         this.getContentPane().add(BorderLayout.NORTH, toolbarComponent);
-        final JSplitPane jsp1 = new JSplitPane(JSplitPane.VERTICAL_SPLIT, this.playfieldDrawer, consoleComponent);
+        final JSplitPane jsp1 = new JSplitPane(JSplitPane.VERTICAL_SPLIT, this.playfieldDrawer, bottomPane);
         jsp1.setOneTouchExpandable(true);
         jsp1.setResizeWeight(0.8);
         final JSplitPane jsp2 = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, jsp1, sidebarComponent);
@@ -180,5 +182,6 @@ public class SwingGameWindow extends JFrame implements GameWindow {
     
     private void cleanup() {
         // TODO implement simulation
+        this.console.cleanup();
     }
 }

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingPlayfieldDrawer.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingPlayfieldDrawer.java
@@ -31,7 +31,6 @@ import javax.swing.JPanel;
 import javax.swing.RepaintManager;
 import javax.swing.SwingUtilities;
 
-import de.unistuttgart.informatik.fius.icge.log.Logger;
 import de.unistuttgart.informatik.fius.icge.ui.Drawable;
 import de.unistuttgart.informatik.fius.icge.ui.PlayfieldDrawer;
 import de.unistuttgart.informatik.fius.icge.ui.SimulationProxy;
@@ -523,24 +522,22 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
         if (this.activeTool == ControlButtonState.ADD) {
             final String type = this.selectedEntityType;
             if ((type == null) || type.equals("")) {
-                Logger.simout.println("Could not spawn entity, no type selected!");
+                System.out.println("Could not spawn entity, no type selected!");
                 return;
             }
             try {
                 this.simulationProxy.spawnEntityAt(type, x, y, null);
             } catch (final Exception e) {
-                Logger.simout.println(
-                        "Error while spawning entity of type " + type + " at (x=" + x + ", y=" + y + "). (See system log for details)"
-                );
-                e.printStackTrace(Logger.error);
+                System.out.println("Error while spawning entity of type " + type + " at (x=" + x + ", y=" + y + ").");
+                e.printStackTrace();
             }
         }
         if (this.activeTool == ControlButtonState.SUB) {
             try {
                 this.simulationProxy.clearCell(x, y);
             } catch (final Exception e) {
-                Logger.simout.println("Error while clearing the cell (x=" + x + ", y=" + y + "). (See system log for details)");
-                e.printStackTrace(Logger.error);
+                System.out.println("Error while clearing the cell (x=" + x + ", y=" + y + ").");
+                e.printStackTrace();
             }
         }
         this.repaint();


### PR DESCRIPTION
Refactor the static Logger class to only intercept stdout and stderr and not provide additional output streams.

All instances of `Logger.out.println`, `Logger.simout.println` were changed to `System.out` and some messages were updated.
All instances of `e.printStackTrace(Logger.error)`, `e.printStackTrace(Logger.simerror)` were changed to `e.printStackTrace()`. 

The console in the ui was completely refactored:
The interface was cleaned up.
The console subscribes itself to stdout and stderr. (And unsubscribes on window close.)
The console streams buffer the single character updates into lines to reduce update calls to the text pane.
The console is now again in a tab. This was done with the intention to add a tab with a task verifier output/task description later.

Closes #150
Related to #123 