### PR TITLE
Stop simulation

### DIFF
--- a/ICGE-ManualStart/src/main/java/de/unistuttgart/informatik/fius/icge/manualstart/ManualStartSimulation.java
+++ b/ICGE-ManualStart/src/main/java/de/unistuttgart/informatik/fius/icge/manualstart/ManualStartSimulation.java
@@ -47,7 +47,7 @@ public class ManualStartSimulation {
         final Simulation sim = sb.getBuiltSimulation();
         
         w.start();
-        sim.attachToWindow(w);
+        sim.attachToWindow(w, true);
         sim.runTask(new TestTask());
     }
     

--- a/ICGE-ManualStart/src/main/java/de/unistuttgart/informatik/fius/icge/manualstart/ManualStartSimulation.java
+++ b/ICGE-ManualStart/src/main/java/de/unistuttgart/informatik/fius/icge/manualstart/ManualStartSimulation.java
@@ -47,7 +47,7 @@ public class ManualStartSimulation {
         final Simulation sim = sb.getBuiltSimulation();
         
         w.start();
-        sim.attachToWindow(w, false);
+        sim.attachToWindow(w, true);
         sim.runTask(new TestTask());
     }
     

--- a/ICGE-ManualStart/src/main/java/de/unistuttgart/informatik/fius/icge/manualstart/ManualStartSimulation.java
+++ b/ICGE-ManualStart/src/main/java/de/unistuttgart/informatik/fius/icge/manualstart/ManualStartSimulation.java
@@ -47,7 +47,7 @@ public class ManualStartSimulation {
         final Simulation sim = sb.getBuiltSimulation();
         
         w.start();
-        sim.attachToWindow(w, true);
+        sim.attachToWindow(w, false);
         sim.runTask(new TestTask());
     }
     

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Simulation.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/Simulation.java
@@ -75,7 +75,26 @@ public interface Simulation {
     void attachToWindow(GameWindow window);
     
     /**
+     * Attach this simulation to the given window.
+     * 
+     * @param window
+     *     The window to attach to
+     * @param stopWithWindowClose
+     *     If {@code true} the simulation will stop when the attached window is closed
+     */
+    void attachToWindow(GameWindow window, boolean stopWithWindowClose);
+    
+    /**
+     * Irreversibly stop the simulation and all running background tasks and programs.
+     * 
+     * Calling this method twice will not throw an exception.
+     */
+    void stop();
+    
+    /**
      * Run the given task in the background.
+     * 
+     * Only one task can be run for a simulation so calling this twice will throw an exception.
      * 
      * @param taskToRun
      *     The task to run

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulation.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulation.java
@@ -125,12 +125,12 @@ public class StandardSimulation implements Simulation {
     
     @Override
     public void stop() {
-        this.simulationClock.stop();
         if (this.runningTask != null) {
             this.runningTask.cancel();
             this.runningTask = null;
         }
         this.programRunner.stopAll();
+        this.simulationClock.shutdown(); // stop the clock for good
     }
     
     @Override

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationClock.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationClock.java
@@ -259,6 +259,14 @@ public class StandardSimulationClock implements SimulationClock {
         } else throw new ListenerSetException();
     }
     
+    /**
+     * Remove the state change listener, that gets called when the clock get's started or paused through public API and
+     * is responsible for informing the UI.
+     */
+    public void removeStateChangeListener() {
+        this.stateChangeListener = null;
+    }
+    
     @Override
     public void registerTickListener(final Function<Long, Boolean> listener) {
         if (this.shuttingDown) return;

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationClock.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationClock.java
@@ -73,7 +73,7 @@ public class StandardSimulationClock implements SimulationClock {
     public StandardSimulationClock() {
         this.tickListeners = new ArrayList<>();
         this.postTickListeners = new ArrayList<>();
-        this.timer = new Timer("STM-TickTimer");
+        this.timer = new Timer("STM-TickTimer", true);
         this.tickCount = -1;
         this.period = SimulationClock.DEFAULT_RENDER_TICK_PERIOD;
         this.shuttingDown = false;

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
@@ -201,10 +201,8 @@ public class StandardSimulationProxy implements SimulationProxy {
     
     @Override
     public void windowClosed() {
-        // clear listeners first        
+        // clear listeners first
         // but do not clear tick listeners (see constructor for explanation)
-        //this.simulationClock.setAnimationTickListener(null); // setting null just provokes null pointers
-        //this.simulationClock.registerPostTickListener(null); // setting null just provokes null pointers
         this.simulationClock.removeStateChangeListener();
         this.playfield.removeDrawablesChangedListener();
         this.playfield.removeSimulationTreeEntityAddedListener();

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import de.unistuttgart.informatik.fius.icge.simulation.Position;
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
@@ -112,6 +111,11 @@ public class StandardSimulationProxy implements SimulationProxy {
             updateEntityInspector();
             return true; // post tick listener could be removed by returning false here
         });
+    }
+    
+    @Override
+    public void attachToGameWindow(final GameWindow window) {
+        this.attachToGameWindow(window, false);
     }
     
     @Override

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/entity/StandardEntityTypeRegistry.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/entity/StandardEntityTypeRegistry.java
@@ -90,7 +90,7 @@ public class StandardEntityTypeRegistry implements EntityTypeRegistry {
     }
     
     /**
-     * Add entity selector listener that gets informed about all entity types added.
+     * Set an entity selector listener that gets informed about all entity types added.
      *
      * @param listener
      *     the listener to set; use null to remove listener
@@ -106,6 +106,13 @@ public class StandardEntityTypeRegistry implements EntityTypeRegistry {
             }
             this.entityRegisteredListener = listener;
         } else throw new ListenerSetException();
+    }
+    
+    /**
+     * Remove the set entity selector listener that gets informed about all entity types added.
+     */
+    public synchronized void removeEntityRegisteredListener() {
+        this.entityRegisteredListener = null;
     }
     
     /**

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -96,7 +96,9 @@ public class StandardPlayfield implements Playfield {
             }
         }
         try {
-            this.drawablesChangedListener.accept(drawables);
+            if (this.drawablesChangedListener != null) {
+                this.drawablesChangedListener.accept(drawables);
+            }
         } catch (@SuppressWarnings("unused") final IllegalStateException e) {
             //If we are not attached to a simultion we do not need to draw anything
         }
@@ -224,7 +226,10 @@ public class StandardPlayfield implements Playfield {
         );
         this.findNodeForEntity(entity, true).appendChild(newNode);
         
-        this.simulationTreeEntityAddedListener.accept(newNode, entity);
+        if (this.simulationTreeEntityAddedListener != null) {
+            // TODO check for bugs with simulation tree when window is reattached or attached late
+            this.simulationTreeEntityAddedListener.accept(newNode, entity);
+        }
     }
     
     @Override
@@ -276,7 +281,10 @@ public class StandardPlayfield implements Playfield {
         for (final SimulationTreeNode child : node.getChildren()) {
             if (child.getElementId().equals(Integer.toHexString(entity.hashCode()))) {
                 node.removeChild(child);
-                this.simulationTreeEntityRemovedListener.accept(child);
+                if (this.simulationTreeEntityRemovedListener != null) {
+                    // TODO check for bugs with simulation tree when window is reattached or attached late
+                    this.simulationTreeEntityRemovedListener.accept(child);
+                }
             }
         }
     }
@@ -350,6 +358,13 @@ public class StandardPlayfield implements Playfield {
     }
     
     /**
+     * Remove the listener for when an entity is added to the simulation tree.
+     */
+    public void removeSimulationTreeEntityAddedListener() {
+        this.simulationTreeEntityAddedListener = null;
+    }
+    
+    /**
      * Set the listener for when an entity is removed from the simulation tree.
      *
      * @param listener
@@ -359,6 +374,13 @@ public class StandardPlayfield implements Playfield {
         if ((this.simulationTreeEntityRemovedListener == null) || (listener == null)) {
             this.simulationTreeEntityRemovedListener = listener;
         } else throw new ListenerSetException();
+    }
+    
+    /**
+     * Remove the listener for when an entity is removed from the simulation tree.
+     */
+    public void removeSimulationTreeEntityRemovedListener() {
+        this.simulationTreeEntityRemovedListener = null;
     }
     
     /**
@@ -372,6 +394,14 @@ public class StandardPlayfield implements Playfield {
         if ((this.drawablesChangedListener == null) || (listener == null)) {
             this.drawablesChangedListener = listener;
         } else throw new ListenerSetException();
+    }
+    
+    /**
+     * Remove the listener for when the drawables on the playfield changed. This listener is responsible for informing
+     * the UI.
+     */
+    public void removeDrawablesChangedListener() {
+        this.drawablesChangedListener = null;
     }
     
     @Override

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/programs/StandardProgramRunner.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/programs/StandardProgramRunner.java
@@ -50,7 +50,7 @@ public class StandardProgramRunner {
         final ForkJoinWorkerThreadFactory factory = pool -> {
             final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
             worker.setName("ProgramThread-" + worker.getPoolIndex());
-            worker.isDaemon();
+            worker.setDaemon(true);
             return worker;
         };
         

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/programs/StandardProgramRunner.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/programs/StandardProgramRunner.java
@@ -84,9 +84,9 @@ public class StandardProgramRunner {
             try {
                 program.run(entity);
             } catch (@SuppressWarnings("unused") final UncheckedInterruptedException e) {
-                System.out.println("Running program for entity " + entity.toString() + " was stopped.");
+                System.out.println("The running program " + program.toString() + " for entity " + entity.toString() + " was stopped.");
             } catch (@SuppressWarnings("unused") final CancellationException e) {
-                System.out.println("Running program for entity " + entity.toString() + " was stopped.");
+                System.out.println("The running program " + program.toString() + " for entity " + entity.toString() + " was stopped.");
             } catch (final Exception e) {
                 System.out.println("----------------------------------------------");
                 System.out.println("The following exception happened while running a program for the entity " + entity.toString());

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/tasks/StandardTaskRunner.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/tasks/StandardTaskRunner.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 import de.unistuttgart.informatik.fius.icge.simulation.Simulation;
+import de.unistuttgart.informatik.fius.icge.simulation.exception.UncheckedInterruptedException;
 import de.unistuttgart.informatik.fius.icge.simulation.tasks.Task;
 
 
@@ -70,16 +71,22 @@ public class StandardTaskRunner {
         try {
             this.taskToRun.run(this.sim);
             return true;
+        } catch (@SuppressWarnings("unused") final UncheckedInterruptedException e) {
+            // task was interrupted on simulation.stop()
+            System.out.println("----------------------------------------------");
+            System.out.println("The task " + this.taskToRun.toString() + " was aborted.");
+            System.out.println("----------------------------------------------");
+            return false;
         } catch (final CancellationException e) {
             //Simulation was stopped before completion of the task.
             System.out.println("----------------------------------------------");
-            System.out.println("The task was aborted.");
+            System.out.println("The task " + this.taskToRun.toString() + " was aborted.");
             e.printStackTrace();
             System.out.println("----------------------------------------------");
             return false;
         } catch (final Exception e) {
             System.out.println("----------------------------------------------");
-            System.out.println("The following exception caused a task failure:");
+            System.out.println("The following exception caused the task " + this.taskToRun.toString() + " to fail:");
             e.printStackTrace();
             System.out.println("----------------------------------------------");
             return false;

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/tasks/StandardTaskRunner.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/tasks/StandardTaskRunner.java
@@ -56,9 +56,12 @@ public class StandardTaskRunner {
     }
     
     /**
-     * Run the given task
+     * Run the given task.
+     * <p>
+     * This method is idempotent and will just return the completable future of the running task if called again.
      *
-     * @return true if the task was completed successfully, false if an exception was thrown in the run method
+     * @return CompletableFuture containing the task result: true if the task was completed successfully, false if an
+     *     exception was thrown in the run method of the task
      */
     public CompletableFuture<Boolean> runTask() {
         if (this.taskResult != null) return this.taskResult;

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/SimulationProxy.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/SimulationProxy.java
@@ -30,8 +30,15 @@ public interface SimulationProxy {
      *
      * @param gameWindow
      *     The game window to attach to
+     * @param stopWithWindowClose
+     *     If {@code true} the simulation will stop when the attached window is closed
      */
-    void attachToGameWindow(GameWindow gameWindow);
+    void attachToGameWindow(GameWindow gameWindow, boolean stopWithWindowClose);
+    
+    /**
+     * Called when the window is closing.
+     */
+    void windowClosed();
     
     //
     // Toolbar

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/SimulationProxy.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/SimulationProxy.java
@@ -9,9 +9,6 @@
  */
 package de.unistuttgart.informatik.fius.icge.ui;
 
-import java.util.Set;
-
-
 /**
  * The SimulationProxy interface. This is used for communication most between the UI and the simulation.
  * <p>
@@ -24,6 +21,14 @@ import java.util.Set;
  * @version 1.0
  */
 public interface SimulationProxy {
+    
+    /**
+     * Attach this simulation proxy to a specific game window.
+     *
+     * @param gameWindow
+     *     The game window to attach to
+     */
+    void attachToGameWindow(GameWindow gameWindow);
     
     /**
      * Attach this simulation proxy to a specific game window.

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingGameWindow.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingGameWindow.java
@@ -51,6 +51,8 @@ public class SwingGameWindow extends JFrame implements GameWindow {
     private final SwingConsole           console;
     private final SwingTaskStatusDisplay taskStatus;
     
+    private SimulationProxy simulationProxy;
+    
     /**
      * Create a new Swing game window using the given submodules.
      *
@@ -81,6 +83,7 @@ public class SwingGameWindow extends JFrame implements GameWindow {
     
     @Override
     public void setSimulationProxy(final SimulationProxy simulationProxy) {
+        this.simulationProxy = simulationProxy;
         this.playfieldDrawer.setSimulationProxy(simulationProxy);
         this.toolbar.setSimulationProxy(simulationProxy);
         this.entitySidebar.setSimulationProxy(simulationProxy);
@@ -191,7 +194,7 @@ public class SwingGameWindow extends JFrame implements GameWindow {
     }
     
     private void cleanup() {
-        // TODO implement simulation
         this.console.cleanup();
+        this.simulationProxy.windowClosed();
     }
 }


### PR DESCRIPTION
Add a function to stop the simulation.
Add functionality to the SimulationHost to stop the simulation when the window is closed (if requested with attachGameWindow)
Refactor threading model to (only) allow jvm to exit iff no window is open and no task is running.