### PR TITLE
Fix entity waiting for operation while holding operation lock

### DIFF
--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/entity/BasicEntity.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/entity/BasicEntity.java
@@ -33,7 +33,9 @@ public abstract class BasicEntity implements Entity {
     /** The current (weak) reference to the playfield. */
     private WeakReference<Playfield> field;
     
-    /** Lock object to ensure no two long running operations (>= 1 clock tick) are scheduled at the same time. */
+    /**
+     * Lock object to ensure no two long running operations ({@code >= 1} clock tick) are scheduled at the same time.
+     */
     private Object                    operationQueueLock = new Object();
     /** The completable future representing the completion of the last enqueued operation. */
     protected CompletableFuture<Void> endOfLastEnqueuedOperation;
@@ -139,7 +141,7 @@ public abstract class BasicEntity implements Entity {
     /**
      * Prevent this entity from performing any long running operation for {@code ticks} simulation ticks.
      * <p>
-     * Only operations that take >= 1 clock ticks to execute will be affected by this sleep.
+     * Only operations that take {@code >= 1} clock ticks to execute will be affected by this sleep.
      * 
      * @param ticks
      *     numberof simulation ticks to pause; must be {@code > 0}

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/entity/GreedyEntity.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/entity/GreedyEntity.java
@@ -27,6 +27,9 @@ import de.unistuttgart.informatik.fius.icge.simulation.exception.EntityNotOnFiel
  */
 public abstract class GreedyEntity extends MovableEntity implements EntityCollector {
     
+    /** A lock to synchronize all operations involving the entities inventory. */
+    protected final Object inventoryOperationLock = new Object();
+    
     private final Inventory inventory = new Inventory();
     
     /**
@@ -62,7 +65,7 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
         Position myPos;
         Position otherPos;
         
-        synchronized (this.operationLock) {
+        synchronized (this.inventoryOperationLock) {
             try {
                 myPos = this.getPosition();
                 otherPos = entity.getPosition();
@@ -101,7 +104,7 @@ public abstract class GreedyEntity extends MovableEntity implements EntityCollec
     public void drop(final CollectableEntity entity, final Position pos) {
         if ((entity == null) || (pos == null)) throw new IllegalArgumentException("An argument is null.");
         Position myPos;
-        synchronized (this.operationLock) {
+        synchronized (this.inventoryOperationLock) {
             try {
                 myPos = this.getPosition();
             } catch (final EntityNotOnFieldException e) {


### PR DESCRIPTION
This fixes the bug that no operation can be done on the entity when a second
long running operation is waiting for a first one to finish.
This behaviour is counterintuitive since actions are not blocked when only
one long running operation blocks the entity.