### PR TITLE
Run deploy GH pages workflow on relase publish and change

### DIFF
--- a/.github/workflows/deployGhPages.yml
+++ b/.github/workflows/deployGhPages.yml
@@ -23,6 +23,8 @@ on:
   push:
     branches: [ master ]
     tags: [ '**' ]
+  release:
+    types: [ published, edited ]
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
This is useful to manually (re)trigger the run for tags