### PR TITLE
Display the number of coins on a tile

### DIFF
--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingPlayfieldDrawer.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingPlayfieldDrawer.java
@@ -89,6 +89,11 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
     private boolean              useDoubleBuffer = true;
     private boolean              syncToscreen    = true;
     
+    private double dpiScale;
+    
+    private Font scaleFont;
+    private Font font;
+    
     /**
      * Create a new SwingPlayfieldDrawer.
      * <p>
@@ -109,10 +114,12 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
         this.CELL_SIZE = (int) Math.floor(32 * dpiScale);
         this.offsetX = this.CELL_SIZE;
         this.offsetY = this.CELL_SIZE;
+        this.dpiScale = dpiScale;
         
         Font font = this.getFont();
-        final int newFontSize = (int) Math.floor(12 * dpiScale);
-        this.setFont(new Font(font.getFontName(), font.getStyle(), newFontSize));
+        final int newFontSize = (int) Math.floor(12 * dpiScale * this.scale);
+        this.font = new Font(font.getFontName(), font.getStyle(), newFontSize);
+        this.setFont(this.font);
     }
     
     /**
@@ -191,9 +198,9 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
     @Override
     public void setDrawables(final List<Drawable> drawables) {
         this.drawables = drawables.stream().sorted(Comparator.naturalOrder()).collect(Collectors.toUnmodifiableList());
-        this.animatedDrawables = drawables.stream().filter(
-                d -> d.isAnimated() || this.textureRegistry.isTextureAnimated(d.getTextureHandle())
-        ).collect(Collectors.toUnmodifiableList());
+        this.animatedDrawables = drawables.stream()
+                .filter(d -> d.isAnimated() || this.textureRegistry.isTextureAnimated(d.getTextureHandle()))
+                .collect(Collectors.toUnmodifiableList());
         this.fullRepaintNeeded = true;
         this.draw(this.currentFrame);
     }
@@ -227,9 +234,9 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
                     final Rectangle visible = this.getVisibleRect();
                     final double cellSize = this.CELL_SIZE * this.scale;
                     final int textureSize = Math.toIntExact(Math.round(cellSize));
-                    final Optional<Rectangle> rectToDraw = this.animatedDrawables.stream().map(
-                            d -> this.getScreenPointFromCellCoordinates(d.getX(), d.getY(), cellSize)
-                    ).map(p -> SwingPlayfieldDrawer.getPaintRectFromPoint(p, textureSize)).filter(r -> r.intersects(visible))
+                    final Optional<Rectangle> rectToDraw = this.animatedDrawables.stream()
+                            .map(d -> this.getScreenPointFromCellCoordinates(d.getX(), d.getY(), cellSize))
+                            .map(p -> SwingPlayfieldDrawer.getPaintRectFromPoint(p, textureSize)).filter(r -> r.intersects(visible))
                             .reduce((final Rectangle r1, final Rectangle r2) -> {
                                 r1.add(r2);
                                 return r1;
@@ -262,9 +269,9 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
             }
         });
         // filter out finished animations
-        this.animatedDrawables = this.drawables.stream().filter(
-                d -> d.isAnimated() || this.textureRegistry.isTextureAnimated(d.getTextureHandle())
-        ).collect(Collectors.toUnmodifiableList());
+        this.animatedDrawables = this.drawables.stream()
+                .filter(d -> d.isAnimated() || this.textureRegistry.isTextureAnimated(d.getTextureHandle()))
+                .collect(Collectors.toUnmodifiableList());
     }
     
     @Override
@@ -272,6 +279,9 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
         this.scale = 1.0;
         this.offsetX = this.CELL_SIZE;
         this.offsetY = this.CELL_SIZE;
+        Font font = this.getFont();
+        final int newFontSize = (int) Math.floor(12 * this.dpiScale * this.scale);
+        this.scaleFont = new Font(font.getFontName(), font.getStyle(), newFontSize);
     }
     
     @Override
@@ -425,18 +435,45 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
             final Double scaleAdjust
     ) {
         final double cellSize = this.CELL_SIZE * this.scale;
-        final int textureSize = Math.toIntExact(Math.round(cellSize * scaleAdjust));
         final Texture texture = this.textureRegistry.getTextureForHandle(drawable.getTextureHandle());
         // limit count to available offsets
+        int x = Math.toIntExact(Math.round((drawable.getX() * cellSize) + this.offsetX));
+        int y = Math.toIntExact(Math.round((drawable.getY() * cellSize) + this.offsetY));
+        int textureSize = Math.toIntExact(Math.round(cellSize));
         final int limitedCount = Math.min(Math.min(xOffsets.length, yOffsets.length), count);
-        for (int i = 0; i < limitedCount; i++) {
-            // intra cell offsets
-            final double tmpOffsetX = cellSize * xOffsets[i];
-            final double tmpOffsetY = cellSize * yOffsets[i];
-            final int x = Math.toIntExact(Math.round((drawable.getX() * cellSize) + this.offsetX + tmpOffsetX));
-            final int y = Math.toIntExact(Math.round((drawable.getY() * cellSize) + this.offsetY + tmpOffsetY));
+        if (count > limitedCount) {
             texture.drawTexture(this.currentFrame, g, x, y, textureSize, textureSize);
+            drawNumber(count, g, x, y);
+        } else {
+            textureSize = Math.toIntExact(Math.round(cellSize * scaleAdjust));
+            for (int i = 0; i < limitedCount; i++) {
+                // intra cell offsets
+                final double tmpOffsetX = cellSize * xOffsets[i];
+                final double tmpOffsetY = cellSize * yOffsets[i];
+                x = Math.toIntExact(Math.round((drawable.getX() * cellSize) + this.offsetX + tmpOffsetX));
+                y = Math.toIntExact(Math.round((drawable.getY() * cellSize) + this.offsetY + tmpOffsetY));
+                texture.drawTexture(this.currentFrame, g, x, y, textureSize, textureSize);
+            }
         }
+    }
+    
+    private void drawNumber(int count, Graphics g, int x, int y) {
+        final double cellSize = this.CELL_SIZE * this.scale;
+        g.setFont(this.scaleFont);
+        int xOffset = 0;
+        int yOffset = (int) (0.6 * cellSize);
+        switch (Integer.toString(count).length()) {
+            case 2:
+                xOffset = (int) (0.25 * cellSize);
+                break;
+            case 3:
+                xOffset = (int) (0.175 * cellSize);
+                break;
+            default:
+                break;
+        }
+        g.drawString("" + count, x + xOffset, y + yOffset);
+        g.setFont(this.font);
     }
     
     private void paintOverlay(final Graphics g) {
@@ -585,6 +622,10 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
         this.scale = newScale;
         this.offsetX += dx;
         this.offsetY += dy;
+        
+        Font font = this.getFont();
+        final int newFontSize = (int) Math.floor(12 * this.dpiScale * this.scale);
+        this.scaleFont = new Font(font.getFontName(), font.getStyle(), newFontSize);
         this.repaint();
     }
     

--- a/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingPlayfieldDrawer.java
+++ b/ICGE-Ui/src/main/java/de/unistuttgart/informatik/fius/icge/ui/internal/SwingPlayfieldDrawer.java
@@ -198,9 +198,9 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
     @Override
     public void setDrawables(final List<Drawable> drawables) {
         this.drawables = drawables.stream().sorted(Comparator.naturalOrder()).collect(Collectors.toUnmodifiableList());
-        this.animatedDrawables = drawables.stream()
-                .filter(d -> d.isAnimated() || this.textureRegistry.isTextureAnimated(d.getTextureHandle()))
-                .collect(Collectors.toUnmodifiableList());
+        this.animatedDrawables = drawables.stream().filter(
+                d -> d.isAnimated() || this.textureRegistry.isTextureAnimated(d.getTextureHandle())
+        ).collect(Collectors.toUnmodifiableList());
         this.fullRepaintNeeded = true;
         this.draw(this.currentFrame);
     }
@@ -234,9 +234,9 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
                     final Rectangle visible = this.getVisibleRect();
                     final double cellSize = this.CELL_SIZE * this.scale;
                     final int textureSize = Math.toIntExact(Math.round(cellSize));
-                    final Optional<Rectangle> rectToDraw = this.animatedDrawables.stream()
-                            .map(d -> this.getScreenPointFromCellCoordinates(d.getX(), d.getY(), cellSize))
-                            .map(p -> SwingPlayfieldDrawer.getPaintRectFromPoint(p, textureSize)).filter(r -> r.intersects(visible))
+                    final Optional<Rectangle> rectToDraw = this.animatedDrawables.stream().map(
+                            d -> this.getScreenPointFromCellCoordinates(d.getX(), d.getY(), cellSize)
+                    ).map(p -> SwingPlayfieldDrawer.getPaintRectFromPoint(p, textureSize)).filter(r -> r.intersects(visible))
                             .reduce((final Rectangle r1, final Rectangle r2) -> {
                                 r1.add(r2);
                                 return r1;
@@ -269,9 +269,9 @@ public class SwingPlayfieldDrawer extends JPanel implements PlayfieldDrawer {
             }
         });
         // filter out finished animations
-        this.animatedDrawables = this.drawables.stream()
-                .filter(d -> d.isAnimated() || this.textureRegistry.isTextureAnimated(d.getTextureHandle()))
-                .collect(Collectors.toUnmodifiableList());
+        this.animatedDrawables = this.drawables.stream().filter(
+                d -> d.isAnimated() || this.textureRegistry.isTextureAnimated(d.getTextureHandle())
+        ).collect(Collectors.toUnmodifiableList());
     }
     
     @Override


### PR DESCRIPTION
Display the number of Objects on a tile as a number over the texture, if it is greater than the limit Count (currently 9).
The number centers itself in the tile, but is only contained in the tile for numbers with four digits or less.
However, this is not a problem as the Simulator becomes irresponsive for so many spawned entities.
![grafik](https://user-images.githubusercontent.com/49717341/194370592-0500598a-0866-4c32-94ee-b371041e687d.png)
