### PR TITLE
Limit draw updates

### DIFF
--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -54,10 +54,10 @@ public class StandardPlayfield implements Playfield {
     
     private Consumer<List<Drawable>> drawablesChangedListener;
     
-    private long    lastEntityDraw            = 0;
-    private boolean delayedEntityDraw         = false;
-    private long    timeBetweenDraws          = 32; //the time between draw calls in milliseconds
-    private Thread  delayedDrawEntitiesThread = new Thread();
+    private long             lastEntityDraw            = 0;
+    private volatile boolean delayedEntityDraw         = false;
+    private long             timeBetweenDraws          = 32; //the time between draw calls in milliseconds
+    private Thread           delayedDrawEntitiesThread = new Thread();
     
     private Runnable delayedEntitiesDrawRunnable = () -> {
         long timeSinceLastEntityDraw = System.nanoTime() - this.lastEntityDraw;

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -338,7 +338,7 @@ public class StandardPlayfield implements Playfield {
         
         synchronized (this.playfieldLock) {
             if (
-            	!this.entityPositions.containsKey(entity)
+                !this.entityPositions.containsKey(entity)
             ) throw new EntityNotOnFieldException("The given entity" + entity + "is not on this playfield.");
             
             final Position pos = this.entityPositions.get(entity);

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -97,7 +97,8 @@ public class StandardPlayfield implements Playfield {
     }
     
     /**
-     * Queues a draw update to the playfield drawer. Draw updates are sent to the playfield drawer automatically every 32ms.
+     * Queues a draw update to the playfield drawer. Draw updates are sent to the playfield drawer automatically every
+     * 32ms.
      */
     public void drawEntities() {
         this.awaitingEntityDraw = true;
@@ -107,24 +108,26 @@ public class StandardPlayfield implements Playfield {
      * Converts all entities to drawables and sends them to the playfield drawer.
      */
     private void drawEntitiesInternal() {
-        if (this.awaitingEntityDraw) {
-            final List<Drawable> drawables = new ArrayList<>();
-            for (final Entity entity : this.getAllEntities()) {
-                try {
-                    drawables.add(entity.getDrawInformation());
-                } catch (@SuppressWarnings("unused") final EntityNotOnFieldException e) {
-                    //Entity has been removed from the field while this loop was running.
-                    //Just don't draw it and ignore the exception.
-                }
-            }
+        if (!this.awaitingEntityDraw) { //fast exit as default
+            return; // no updates to draw
+        }
+        final List<Drawable> drawables = new ArrayList<>();
+        for (final Entity entity : this.getAllEntities()) {
             try {
-                if (this.drawablesChangedListener != null) {
-                    this.drawablesChangedListener.accept(drawables);
-                }
-            } catch (@SuppressWarnings("unused") final IllegalStateException e) {
-                //If we are not attached to a simultion we do not need to draw anything
+                drawables.add(entity.getDrawInformation());
+            } catch (@SuppressWarnings("unused") final EntityNotOnFieldException e) {
+                //Entity has been removed from the field while this loop was running.
+                //Just don't draw it and ignore the exception.
             }
         }
+        try {
+            if (this.drawablesChangedListener != null) {
+                this.drawablesChangedListener.accept(drawables);
+            }
+        } catch (@SuppressWarnings("unused") final IllegalStateException e) {
+            //If we are not attached to a simultion we do not need to draw anything
+        }
+        
     }
     
     @Override

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -71,7 +71,7 @@ public class StandardPlayfield implements Playfield {
         this.lastEntityDraw = System.nanoTime();
         this.delayedEntityDraw = false;
         try {
-            Thread.sleep(1); // leave some time between this.delayedEntityDraw = false; and  drawEntitiesInternal(), so as to not lose any draw calls due to poor timing
+            Thread.sleep(10); // leave some time between this.delayedEntityDraw = false; and  drawEntitiesInternal(), so as to not lose any draw calls due to poor timing
         } catch (InterruptedException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -107,9 +107,6 @@ public class StandardPlayfield implements Playfield {
         return simulation;
     }
     
-    /**
-     * Converts all entities to drawables and sends them to the playfield drawer.
-     */
     public void drawEntities() {
         if (!this.delayedEntityDraw) {
             this.delayedEntityDraw = true;
@@ -117,6 +114,9 @@ public class StandardPlayfield implements Playfield {
         }
     }
     
+    /**
+     * Converts all entities to drawables and sends them to the playfield drawer.
+     */
     private void drawEntitiesInternal() {
         final List<Drawable> drawables = new ArrayList<>();
         for (final Entity entity : this.getAllEntities()) {
@@ -207,8 +207,9 @@ public class StandardPlayfield implements Playfield {
         if (entity == null) throw new IllegalArgumentException("The given entity is null.");
         
         synchronized (this.playfieldLock) {
-            if (this.entityPositions.containsKey(entity))
-                throw new EntityAlreadyOnFieldExcpetion("The given entity" + entity + "is already on this playfield.");
+            if (
+                this.entityPositions.containsKey(entity)
+            ) throw new EntityAlreadyOnFieldExcpetion("The given entity" + entity + "is already on this playfield.");
             
             entity.initOnPlayfield(this);
             
@@ -275,8 +276,9 @@ public class StandardPlayfield implements Playfield {
         if (entity == null) throw new IllegalArgumentException("The given entity is null.");
         
         synchronized (this.playfieldLock) {
-            if (!this.entityPositions.containsKey(entity))
-                throw new EntityNotOnFieldException("The given entity" + entity + "is not on this playfield.");
+            if (
+                !this.entityPositions.containsKey(entity)
+            ) throw new EntityNotOnFieldException("The given entity" + entity + "is not on this playfield.");
             
             EntityMoveAction actionToLog = action;
             
@@ -285,10 +287,12 @@ public class StandardPlayfield implements Playfield {
             if (actionToLog == null) {
                 actionToLog = new EntityTeleportAction(this.getSimulation().getSimulationClock().getLastTickNumber(), entity, oldPos, pos);
             } else {
-                if (!actionToLog.getEntity().equals(entity))
-                    throw new IllegalArgumentException("Given action wasn't caused by given entity.");
-                if (!actionToLog.from().equals(oldPos))
-                    throw new IllegalArgumentException("Given action does not start at current position of given entity.");
+                if (
+                    !actionToLog.getEntity().equals(entity)
+                ) throw new IllegalArgumentException("Given action wasn't caused by given entity.");
+                if (
+                    !actionToLog.from().equals(oldPos)
+                ) throw new IllegalArgumentException("Given action does not start at current position of given entity.");
                 if (!actionToLog.to().equals(pos)) throw new IllegalArgumentException("Given action does not end at given pos.");
             }
             
@@ -323,8 +327,9 @@ public class StandardPlayfield implements Playfield {
         if (entity == null) throw new IllegalArgumentException("The given entity is null.");
         
         synchronized (this.playfieldLock) {
-            if (!this.entityPositions.containsKey(entity))
-                throw new EntityNotOnFieldException("The given entity" + entity + "is not on this playfield.");
+            if (
+                !this.entityPositions.containsKey(entity)
+            ) throw new EntityNotOnFieldException("The given entity" + entity + "is not on this playfield.");
             
             final Position pos = this.entityPositions.get(entity);
             this.removeEntityFromCell(pos, entity);

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -97,7 +97,7 @@ public class StandardPlayfield implements Playfield {
     }
     
     /**
-     * Converts all entities to drawables and sends them to the playfield drawer every 32ms.
+     * Queues a draw update to the playfield drawer. Draw updates are sent to the playfield drawer automatically every 32ms.
      */
     public void drawEntities() {
         this.awaitingEntityDraw = true;

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -56,12 +56,13 @@ public class StandardPlayfield implements Playfield {
     
     private long    lastEntityDraw    = 0;
     private boolean delayedEntityDraw = false;
+    private long    timeBetweenDraws  = 16; //the time between draw calls in milliseconds
     
     private Runnable delayedEntitiesDrawRunnable = () -> {
         long timeSinceLastEntityDraw = System.nanoTime() - this.lastEntityDraw;
-        if (timeSinceLastEntityDraw < 16000000) { //update once every 16ms (62.5 Hz)
+        if (timeSinceLastEntityDraw < this.timeBetweenDraws * 1000000) { //update once every 16ms (62.5 Hz)
             try {
-                Thread.sleep(16 - timeSinceLastEntityDraw / 1000000);
+                Thread.sleep(this.timeBetweenDraws - timeSinceLastEntityDraw / 1000000);
             } catch (InterruptedException e) {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
@@ -434,5 +435,24 @@ public class StandardPlayfield implements Playfield {
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + "@" + Integer.toHexString(this.hashCode());
+    }
+    
+    /**
+     * Get's {@link #timeBetweenDraws timeBetweenDraws}
+     * 
+     * @return time waiting between draw calls in milliseconds
+     */
+    public long getTimeBetweenDraws() {
+        return this.timeBetweenDraws;
+    }
+    
+    /**
+     * Set's {@link #timeBetweenDraws timeBetweenDraws}
+     * 
+     * @param timeBetweenDraws
+     *     time waiting between draw calls in milliseconds
+     */
+    public void setTimeBetweenDraws(long timeBetweenDraws) {
+        this.timeBetweenDraws = timeBetweenDraws;
     }
 }

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -69,7 +69,7 @@ public class StandardPlayfield implements Playfield {
                 e.printStackTrace();
             }
         }
-        this.delayedEntityDraw = false;
+        this.awaitingEntityDraw = false;
         drawEntitiesInternal();
         this.lastEntityDraw = System.nanoTime();
     };
@@ -118,8 +118,8 @@ public class StandardPlayfield implements Playfield {
      * recently.
      */
     public void drawEntities() {
-        if (!this.delayedEntityDraw) {
-            this.delayedEntityDraw = true;
+        if (!this.awaitingEntityDraw) {
+            this.awaitingEntityDraw = true;
             new Thread(this.restartDelayedEntitiesDrawThreadRunnable).start();
         }
     }

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -55,7 +55,7 @@ public class StandardPlayfield implements Playfield {
     private Consumer<List<Drawable>> drawablesChangedListener;
     
     private long             lastEntityDraw            = 0;
-    private volatile boolean delayedEntityDraw         = false;
+    private volatile boolean awaitingEntityDraw        = false;
     private long             timeBetweenDraws          = 32; //the time between draw calls in milliseconds
     private Thread           delayedDrawEntitiesThread = new Thread();
     

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -113,7 +113,6 @@ public class StandardPlayfield implements Playfield {
         return simulation;
     }
     
-    
     /**
      * Converts all entities to drawables and sends them to the playfield drawer if the last draw has not occurred
      * recently.

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/playfield/StandardPlayfield.java
@@ -97,8 +97,7 @@ public class StandardPlayfield implements Playfield {
     }
     
     /**
-     * Converts all entities to drawables and sends them to the playfield drawer if the last draw has not occurred
-     * recently.
+     * Converts all entities to drawables and sends them to the playfield drawer every 32ms.
      */
     public void drawEntities() {
         this.awaitingEntityDraw = true;
@@ -431,24 +430,5 @@ public class StandardPlayfield implements Playfield {
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + "@" + Integer.toHexString(this.hashCode());
-    }
-    
-    /**
-     * Get's {@link #timeBetweenDraws timeBetweenDraws}
-     * 
-     * @return time waiting between draw calls in milliseconds
-     */
-    public long getTimeBetweenDraws() {
-        return this.timeBetweenDraws;
-    }
-    
-    /**
-     * Set's {@link #timeBetweenDraws timeBetweenDraws}
-     * 
-     * @param timeBetweenDraws
-     *     time waiting between draw calls in milliseconds
-     */
-    public void setTimeBetweenDraws(long timeBetweenDraws) {
-        this.timeBetweenDraws = timeBetweenDraws;
     }
 }


### PR DESCRIPTION
This change limits the between individual calls of `drawEntities()`. This way  `drawEntities()` is not called every time a new Entity is created. This can reduce Lag when multible entities are added to the PlayingField at the same time. The time between `drawEntities()` calls can be changed with the `setTimeBetweenDraws` method which accepts the time in milliseconds. The time is initially set as 32ms between draw calls, which equates to a maximum of 31.75 Draws/Second. This implements #194.