### PR TITLE
Bugfix selecting despawining entity

### DIFF
--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/inspection/InspectionData.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/inspection/InspectionData.java
@@ -63,6 +63,7 @@ public class InspectionData {
                 // TODO Auto-generated catch block
                 e.printStackTrace();
             } catch (InvocationTargetException e) {
+                // InvocationTargetException is suppressed to prevent crashes from methods that throw an exception when the value is null, e.g. getPosition(); 
             }
         }
         return null;

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/inspection/InspectionData.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/inspection/InspectionData.java
@@ -59,8 +59,10 @@ public class InspectionData {
         if (p != null) {
             try {
                 return p.getValue(obj);
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            } catch (IllegalAccessException | IllegalArgumentException e) {
+                // TODO Auto-generated catch block
                 e.printStackTrace();
+            } catch (InvocationTargetException e) {
             }
         }
         return null;

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
@@ -325,7 +325,11 @@ public class StandardSimulationProxy implements SimulationProxy {
                 type = "readonly_string";
             }
             //TODO: this.inspectionManager.getAttributeType(e, name)
-            final String value = this.inspectionManager.getAttributeValue(e, name).toString();
+            final Object valueObject = this.inspectionManager.getAttributeValue(e, name);
+            String value = "N/A";
+            if (valueObject != null) {
+                value = valueObject.toString();
+            }
             result.add(new EntityInspectorEntry(name, type, value, newValue -> {
                 this.inspectionManager.setAttributeValue(e, name, newValue);
                 this.playfield.drawEntities();

--- a/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
+++ b/ICGE-Simulation/src/main/java/de/unistuttgart/informatik/fius/icge/simulation/internal/StandardSimulationProxy.java
@@ -326,7 +326,7 @@ public class StandardSimulationProxy implements SimulationProxy {
             }
             //TODO: this.inspectionManager.getAttributeType(e, name)
             final Object valueObject = this.inspectionManager.getAttributeValue(e, name);
-            String value = "N/A";
+            String value = "null";
             if (valueObject != null) {
                 value = valueObject.toString();
             }


### PR DESCRIPTION
The ICGE throws an `EntityNotOnFieldException` when an entity is selected that is despawned during execution of the task method.
This pull request supresses the exception and fixes a resulting nullPointer exception. This "fixes" #205 